### PR TITLE
Make Windows workspace UI setup one-shot

### DIFF
--- a/tools/run_workspace_ui.bat
+++ b/tools/run_workspace_ui.bat
@@ -1,13 +1,31 @@
 @echo off
 setlocal EnableExtensions EnableDelayedExpansion
 
-call :find_repo_root "%~dp0"
-if errorlevel 1 exit /b 1
+if /I "%~1"=="--help" goto usage
+if /I "%~1"=="-h" goto usage
+if /I "%~1"=="help" goto usage
 
+call :find_repo_root "%~dp0"
+if errorlevel 1 goto fail
+
+if not exist "%REPO_ROOT%\logs\tools" mkdir "%REPO_ROOT%\logs\tools" >nul 2>nul
+set "WORKSPACE_UI_LOG=%REPO_ROOT%\logs\tools\workspace-ui-windows.log"
+
+echo [workspace-ui] log: %WORKSPACE_UI_LOG%
+call :ensure_admin %*
+if errorlevel 1 goto fail
+
+call :main %* 1>>"%WORKSPACE_UI_LOG%" 2>>&1
+set "WORKSPACE_UI_EXIT_CODE=%ERRORLEVEL%"
+if not "%WORKSPACE_UI_EXIT_CODE%"=="0" goto fail
+exit /b 0
+
+:main
 set "IMAGE_NAME=localhost/octaryn-arch-builder:latest"
 if not "%OCTARYN_ARCH_BUILDER_IMAGE%"=="" set "IMAGE_NAME=%OCTARYN_ARCH_BUILDER_IMAGE%"
 set "BUILDER_VERSION=20260421-2"
 
+echo [workspace-ui] starting one-shot setup from %REPO_ROOT%
 call "%REPO_ROOT%\tools\setup\windows_build_environment.bat" --yes
 if errorlevel 1 exit /b 1
 
@@ -23,30 +41,53 @@ if errorlevel 1 (
   exit /b 1
 )
 
+call :refresh_path
 podman info >nul 2>nul
 if errorlevel 1 (
   echo [error] Podman is not ready after setup.
   exit /b 1
 )
 
-set "CURRENT_BUILDER_VERSION="
-for /f "delims=" %%V in ('podman image inspect "%IMAGE_NAME%" --format "{{ index .Config.Labels \"org.octaryn.arch-builder.version\" }}" 2^>nul') do set "CURRENT_BUILDER_VERSION=%%V"
-if not "%CURRENT_BUILDER_VERSION%"=="%BUILDER_VERSION%" (
-  echo [workspace-ui] building Arch builder image %IMAGE_NAME%
-  podman build --build-arg "OCTARYN_ARCH_BUILDER_VERSION=%BUILDER_VERSION%" -t "%IMAGE_NAME%" -f "%REPO_ROOT%\tools\podman\Containerfile.arch-build" "%REPO_ROOT%\tools\podman"
-  if errorlevel 1 exit /b 1
-) else (
-  echo [workspace-ui] Arch builder image ready: %IMAGE_NAME%
-)
+echo [workspace-ui] building or refreshing Arch builder image %IMAGE_NAME%
+podman build --build-arg "OCTARYN_ARCH_BUILDER_VERSION=%BUILDER_VERSION%" -t "%IMAGE_NAME%" -f "%REPO_ROOT%\tools\podman\Containerfile.arch-build" "%REPO_ROOT%\tools\podman"
+if errorlevel 1 exit /b 1
 
-if not exist "%REPO_ROOT%\logs\tools" mkdir "%REPO_ROOT%\logs\tools"
 echo [workspace-ui] validating workspace mount in %IMAGE_NAME%
 podman run --rm -v "%REPO_ROOT%:/workspace" --workdir /workspace "%IMAGE_NAME%" bash -lc "test -f CMakePresets.json && test -f tools/ui/workspace_control_app.py && mkdir -p logs/tools && test -w logs/tools"
 if errorlevel 1 exit /b 1
 
 echo [workspace-ui] launching workspace control UI
-%PYTHON_CMD% "%REPO_ROOT%\tools\ui\workspace_control_app.py"
+"%PYTHON_CMD%" "%REPO_ROOT%\tools\ui\workspace_control_app.py"
 exit /b %ERRORLEVEL%
+
+:usage
+echo Usage: run_workspace_ui.bat
+echo Installs/repairs required Windows host tools as Administrator, prepares the Podman builder, and launches the workspace UI.
+echo A log is written to logs\tools\workspace-ui-windows.log.
+exit /b 0
+
+:ensure_admin
+if /I "%~1"=="--elevated" exit /b 0
+net session >nul 2>nul
+if not errorlevel 1 exit /b 0
+echo [workspace-ui] requesting Administrator rights for one-shot install/repair...
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Start-Process -Verb RunAs -FilePath 'cmd.exe' -ArgumentList '/k','call ""%~f0"" --elevated'"
+exit /b 0
+
+:fail
+set "WORKSPACE_UI_EXIT_CODE=%WORKSPACE_UI_EXIT_CODE%"
+if "%WORKSPACE_UI_EXIT_CODE%"=="" set "WORKSPACE_UI_EXIT_CODE=%ERRORLEVEL%"
+if "%WORKSPACE_UI_EXIT_CODE%"=="0" set "WORKSPACE_UI_EXIT_CODE=1"
+echo.
+echo [workspace-ui] failed or relaunched with exit code %WORKSPACE_UI_EXIT_CODE%.
+echo [workspace-ui] Log: %WORKSPACE_UI_LOG%
+echo [workspace-ui] Leaving this window open so you can read the error above.
+pause
+exit /b %WORKSPACE_UI_EXIT_CODE%
+
+:refresh_path
+set "PATH=%PATH%;%LocalAppData%\Microsoft\WindowsApps;%ProgramFiles%\Git\cmd;%ProgramFiles%\RedHat\Podman;%LocalAppData%\Programs\Python\Python313;%LocalAppData%\Programs\Python\Python313\Scripts;%AppData%\Python\Python313\Scripts;%ProgramFiles%\Python313;%ProgramFiles%\Python313\Scripts"
+exit /b 0
 
 :find_repo_root
 set "CURRENT=%~f1"
@@ -65,24 +106,12 @@ set "CURRENT=%PARENT%"
 goto find_repo_root_loop
 
 :find_python
-where py >nul 2>nul
-if not errorlevel 1 (
-  py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >nul 2>nul
-  if not errorlevel 1 (
-    set "PYTHON_CMD=py -3"
-    exit /b 0
-  )
-)
-where python >nul 2>nul
-if not errorlevel 1 (
-  python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >nul 2>nul
-  if not errorlevel 1 (
-    set "PYTHON_CMD=python"
-    exit /b 0
-  )
-)
+call :refresh_path
+set "PYTHON_CMD="
+for /f "usebackq delims=" %%P in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$candidates=@($env:LOCALAPPDATA+'\Programs\Python\Python313\python.exe', $env:USERPROFILE+'\AppData\Local\Programs\Python\Python313\python.exe', $env:ProgramFiles+'\Python313\python.exe'); foreach($p in $candidates){ if(Test-Path -LiteralPath $p){ & $p -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' *> $null; if($LASTEXITCODE -eq 0){ Write-Output $p; exit 0 } } }; $cmd=Get-Command python -ErrorAction SilentlyContinue; if($cmd){ & $cmd.Source -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' *> $null; if($LASTEXITCODE -eq 0){ Write-Output $cmd.Source; exit 0 } }; exit 1"`) do set "PYTHON_CMD=%%~P"
+if defined PYTHON_CMD exit /b 0
 exit /b 1
 
 :check_pyside6
-%PYTHON_CMD% -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
+"%PYTHON_CMD%" -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
 exit /b %ERRORLEVEL%

--- a/tools/setup/windows_build_environment.bat
+++ b/tools/setup/windows_build_environment.bat
@@ -25,6 +25,7 @@ if errorlevel 1 exit /b 1
 call :ensure_podman_machine
 if errorlevel 1 exit /b 1
 
+call :refresh_path
 git --version >nul 2>nul
 if errorlevel 1 (
   echo [error] Git is not available after setup.
@@ -37,7 +38,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-%PYTHON_CMD% -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
+"%PYTHON_CMD%" -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
 if errorlevel 1 (
   echo [error] PySide6 is not importable by the native Python.
   exit /b 1
@@ -48,7 +49,7 @@ exit /b 0
 
 :usage
 echo Usage: windows_build_environment.bat [--yes]
-echo Installs host tools for the Podman-first Octaryn build environment on Windows.
+echo Installs/repairs host tools for the Podman-first Octaryn build environment on Windows.
 exit /b 0
 
 :find_repo_root
@@ -67,93 +68,119 @@ if /I "%PARENT%"=="%CURRENT%" (
 set "CURRENT=%PARENT%"
 goto find_repo_root_loop
 
-:winget_install
+:find_winget
 where winget >nul 2>nul
+if not errorlevel 1 (
+  set "WINGET_CMD=winget"
+  exit /b 0
+)
+if exist "%LocalAppData%\Microsoft\WindowsApps\winget.exe" (
+  set "WINGET_CMD=%LocalAppData%\Microsoft\WindowsApps\winget.exe"
+  exit /b 0
+)
+exit /b 1
+
+:refresh_path
+set "PATH=%PATH%;%LocalAppData%\Microsoft\WindowsApps;%ProgramFiles%\Git\cmd;%ProgramFiles%\RedHat\Podman;%LocalAppData%\Programs\Python\Python313;%LocalAppData%\Programs\Python\Python313\Scripts;%AppData%\Python\Python313\Scripts;%ProgramFiles%\Python313;%ProgramFiles%\Python313\Scripts"
+exit /b 0
+
+:winget_install
+call :find_winget
 if errorlevel 1 (
   echo [error] %~2 is missing and winget is not available to install %~1.
   exit /b 1
 )
 echo [setup] installing %~1 with winget
 if /I "%INSTALL_MODE%"=="yes" (
-  winget install --id %~1 --exact --source winget --silent --accept-package-agreements --accept-source-agreements
+  "%WINGET_CMD%" install --id %~1 --exact --source winget --silent --force --accept-package-agreements --accept-source-agreements
 ) else (
-  winget install --id %~1 --exact --source winget --accept-package-agreements --accept-source-agreements
+  "%WINGET_CMD%" install --id %~1 --exact --source winget --force --accept-package-agreements --accept-source-agreements
 )
-exit /b %ERRORLEVEL%
+set "WINGET_RESULT=%ERRORLEVEL%"
+call :refresh_path
+exit /b %WINGET_RESULT%
+
+:repair_winget_package
+call :find_winget
+if errorlevel 1 exit /b 1
+echo [setup] repairing stale package registration for %~1
+"%WINGET_CMD%" uninstall --id %~1 --silent --accept-source-agreements >nul 2>nul
+"%WINGET_CMD%" install --id %~1 --exact --source winget --silent --force --accept-package-agreements --accept-source-agreements
+set "REPAIR_RESULT=%ERRORLEVEL%"
+call :refresh_path
+exit /b %REPAIR_RESULT%
 
 :ensure_tool
+call :refresh_path
 where %~2 >nul 2>nul
 if not errorlevel 1 exit /b 0
 call :winget_install %~1 %~2
+if errorlevel 1 call :repair_winget_package %~1 %~2
 if errorlevel 1 exit /b 1
+call :refresh_path
+where %~2 >nul 2>nul
+if not errorlevel 1 exit /b 0
+echo [setup] %~2 is still missing after install; forcing repair.
+call :repair_winget_package %~1 %~2
+if errorlevel 1 exit /b 1
+call :refresh_path
 where %~2 >nul 2>nul
 if errorlevel 1 (
-  echo [error] %~2 is still missing. Open a new terminal if winget updated PATH, then rerun this script.
+  echo [error] %~2 is still missing after repair.
   exit /b 1
 )
 exit /b 0
 
 :ensure_python
+call :refresh_path
 call :find_python
 if not errorlevel 1 exit /b 0
 call :winget_install Python.Python.3.13 python
+if errorlevel 1 call :repair_winget_package Python.Python.3.13 python
+if errorlevel 1 exit /b 1
+call :find_python
+if not errorlevel 1 exit /b 0
+echo [setup] Python is still missing after install; forcing repair.
+call :repair_winget_package Python.Python.3.13 python
 if errorlevel 1 exit /b 1
 call :find_python
 if errorlevel 1 (
-  echo [error] Python is still missing. Open a new terminal if winget updated PATH, then rerun this script.
+  echo [error] Python is still missing after repair.
   exit /b 1
 )
 exit /b 0
 
 :find_python
-where py >nul 2>nul
-if not errorlevel 1 (
-  py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >nul 2>nul
-  if not errorlevel 1 (
-    set "PYTHON_CMD=py -3"
-    exit /b 0
-  )
-)
-where python >nul 2>nul
-if not errorlevel 1 (
-  python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >nul 2>nul
-  if not errorlevel 1 (
-    set "PYTHON_CMD=python"
-    exit /b 0
-  )
-)
-for %%P in ("%LocalAppData%\Programs\Python\Python313\python.exe" "%ProgramFiles%\Python313\python.exe") do (
-  if exist "%%~P" (
-    "%%~P" -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)" >nul 2>nul
-    if not errorlevel 1 (
-      set "PYTHON_CMD="%%~P""
-      exit /b 0
-    )
-  )
-)
+call :refresh_path
+set "PYTHON_CMD="
+for /f "usebackq delims=" %%P in (`powershell -NoProfile -ExecutionPolicy Bypass -Command "$candidates=@($env:LOCALAPPDATA+'\Programs\Python\Python313\python.exe', $env:USERPROFILE+'\AppData\Local\Programs\Python\Python313\python.exe', $env:ProgramFiles+'\Python313\python.exe'); foreach($p in $candidates){ if(Test-Path -LiteralPath $p){ & $p -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' *> $null; if($LASTEXITCODE -eq 0){ Write-Output $p; exit 0 } } }; $cmd=Get-Command python -ErrorAction SilentlyContinue; if($cmd){ & $cmd.Source -c 'import sys; raise SystemExit(0 if sys.version_info >= (3,10) else 1)' *> $null; if($LASTEXITCODE -eq 0){ Write-Output $cmd.Source; exit 0 } }; exit 1"`) do set "PYTHON_CMD=%%~P"
+if defined PYTHON_CMD exit /b 0
 exit /b 1
 
 :ensure_pyside6
-%PYTHON_CMD% -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
+"%PYTHON_CMD%" -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
 if not errorlevel 1 exit /b 0
 echo [setup] installing PySide6 for native Python user site
-%PYTHON_CMD% -m ensurepip --upgrade >nul 2>nul
-%PYTHON_CMD% -m pip install --user --upgrade PySide6
+"%PYTHON_CMD%" -m ensurepip --upgrade >nul 2>nul
+"%PYTHON_CMD%" -m pip install --user --upgrade PySide6
 if errorlevel 1 exit /b 1
-%PYTHON_CMD% -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
+"%PYTHON_CMD%" -c "from PySide6 import QtCore, QtGui, QtWidgets" >nul 2>nul
 exit /b %ERRORLEVEL%
 
 :ensure_podman_machine
+call :refresh_path
 podman machine inspect >nul 2>nul
 if errorlevel 1 (
   echo [setup] initializing Podman machine
   podman machine init
   if errorlevel 1 exit /b 1
 )
+echo [setup] starting Podman machine
 podman machine start >nul 2>nul
-podman info >nul 2>nul
-if errorlevel 1 (
-  echo [error] Podman machine did not start cleanly.
-  exit /b 1
+for /L %%I in (1,1,30) do (
+  podman info >nul 2>nul
+  if not errorlevel 1 exit /b 0
+  timeout /t 2 /nobreak >nul
 )
-exit /b 0
+echo [error] Podman machine did not start cleanly.
+exit /b 1


### PR DESCRIPTION
## Summary
- make `run_workspace_ui.bat` self-elevate, log to `logs/tools`, and keep the window open on failure
- make Windows setup repair/install Git, Python 3.13, Podman, PySide6, and Podman machine state in one pass
- refresh PATH inside the same batch session so new installs work without reopening the terminal

## Verification
- removed Git/Python/Podman from the host and reran the launcher from clean state
- confirmed the workspace UI launched after the one-shot setup
- ran `tools\setup\windows_build_environment.bat --yes` from a fresh clone successfully
- ran `tools\run_workspace_ui.bat --help`