### PR TITLE
Fix Arch builder setup on Windows clones

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+* text=auto
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+*.sh text eol=lf
+Containerfile* text eol=lf
+*.Dockerfile text eol=lf
+*.cmake text eol=lf
+CMakeLists.txt text eol=lf

--- a/tools/podman/Containerfile.arch-build
+++ b/tools/podman/Containerfile.arch-build
@@ -2,12 +2,15 @@ FROM docker.io/mstorsjo/llvm-mingw:dev-20260421 AS llvm_mingw
 
 FROM docker.io/archlinux:latest
 
-ARG OCTARYN_ARCH_BUILDER_VERSION=20260421-2
+ARG OCTARYN_ARCH_BUILDER_VERSION=20260501-1
 LABEL org.octaryn.arch-builder.version="${OCTARYN_ARCH_BUILDER_VERSION}"
 
 COPY arch_packages.txt /tmp/octaryn-arch-packages.txt
-RUN pacman -Syu --noconfirm \
-    && pacman -S --needed --noconfirm $(grep -Ev '^[[:space:]]*(#|$)' /tmp/octaryn-arch-packages.txt) \
+RUN pacman-key --init \
+    && pacman-key --populate archlinux \
+    && pacman -Sy --noconfirm archlinux-keyring \
+    && pacman -Syu --noconfirm \
+    && grep -Ev '^[[:space:]]*(#|$)' /tmp/octaryn-arch-packages.txt | tr -d '\r' | xargs pacman -S --needed --noconfirm \
     && pacman -Scc --noconfirm \
     && rm -f /tmp/octaryn-arch-packages.txt
 

--- a/tools/run_workspace_ui.bat
+++ b/tools/run_workspace_ui.bat
@@ -23,7 +23,7 @@ exit /b 0
 :main
 set "IMAGE_NAME=localhost/octaryn-arch-builder:latest"
 if not "%OCTARYN_ARCH_BUILDER_IMAGE%"=="" set "IMAGE_NAME=%OCTARYN_ARCH_BUILDER_IMAGE%"
-set "BUILDER_VERSION=20260421-2"
+set "BUILDER_VERSION=20260501-1"
 
 echo [workspace-ui] starting one-shot setup from %REPO_ROOT%
 call "%REPO_ROOT%\tools\setup\windows_build_environment.bat" --yes


### PR DESCRIPTION
## Summary
- initialize and populate the pacman keyring before updating the Arch builder image
- install the refreshed Arch keyring before the full system upgrade
- strip CRLF carriage returns from `arch_packages.txt` before passing package names to pacman
- bump the Windows workspace UI builder version so the repaired image is rebuilt

## Verification
- built `localhost/octaryn-arch-builder:latest` from `tools/podman/Containerfile.arch-build`
- ran the builder container against the workspace mount and verified Python, .NET, and CMake are available
