### PR TITLE
Add GitHub community rules and templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,24 @@
+# ZSG Studios Community Rules
+
+Octaryn development spaces are for engine development, game development, testing, and player-facing feedback. Keep discussion useful, specific, and respectful.
+
+## Expected Behavior
+
+- Stay on topic for the issue, pull request, or discussion.
+- Give reproduction steps, logs, screenshots, captures, or build details when reporting problems.
+- Critique code, designs, and behavior without attacking people.
+- Respect project boundaries between engine, client, server, basegame, tools, and community feedback.
+- Keep private tokens, credentials, unreleased assets, and personal information out of public posts.
+
+## Not Allowed
+
+- Harassment, hate speech, threats, or personal attacks.
+- Spam, low-effort duplicate reports, or unrelated promotion.
+- Posting malware, credential dumps, exploits, or destructive instructions outside a responsible security report.
+- Sharing copyrighted assets or code that ZSG Studios cannot legally use.
+- Derailing bug reports, PR reviews, or release discussions with unrelated arguments.
+
+## Enforcement
+
+Maintainers may edit labels, close duplicates, hide comments, lock threads, or remove access when needed to keep the project clean and usable.
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Octaryn
+
+Octaryn is a ZSG Studios engine project. Keep contributions focused, reproducible, and aligned with the current architecture.
+
+## Ground Rules
+
+- Use clear names for files, folders, types, functions, and tests.
+- Keep changes scoped to one purpose.
+- Do not add legacy compatibility layers, fallback systems, or deprecated APIs unless a maintainer asks for them.
+- Preserve the separation between `octaryn-client`, `octaryn-server`, `octaryn-basegame`, `octaryn-shared`, tools, docs, build, and validation.
+- Do not commit generated build output, logs, local secrets, or temporary files.
+- Do not submit copyrighted code or assets from projects that ZSG Studios cannot use.
+
+## Bugs
+
+Bug reports should include:
+
+- Build or commit tested.
+- Operating system and graphics/API details when relevant.
+- Steps to reproduce.
+- Expected result.
+- Actual result.
+- Logs, screenshots, captures, or small test data when useful.
+
+## Pull Requests
+
+Before opening a PR:
+
+- Keep the branch up to date with `main`.
+- Run the most relevant build or validation checks for the touched area.
+- Explain what changed and why.
+- Link related issues when possible.
+- Call out any known gaps or follow-up work.
+
+## Reviews
+
+Reviews should focus on correctness, architecture boundaries, performance, maintainability, and test coverage. Resolve review threads when the requested change or answer is complete.
+

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report an Octaryn engine, client, server, basegame, or tooling bug.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: Keep reports concrete. Include enough detail for someone else to reproduce the problem.
+  - type: input
+    id: build
+    attributes:
+      label: Build or commit
+      description: Which build, branch, or commit did you test?
+      placeholder: "main @ commit, local debug build, release tag"
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Rendering
+        - Client
+        - Server
+        - Networking
+        - Build
+        - Tooling
+        - Gameplay
+        - Performance
+        - Assets
+        - Basegame
+        - Shared API
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual result
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs, screenshots, captures, or notes
+      description: Attach logs, screenshots, RenderDoc captures, Tracy captures, or focused details if available.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ZSG Studios Discord
+    url: https://discord.com/channels/1375201839670235187
+    about: Use Discord for community discussion, player help, and quick feedback.
+

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,42 @@
+name: Feedback
+description: Suggest an improvement for Octaryn.
+title: "[Feedback] "
+labels:
+  - feedback
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Design
+        - UX
+        - Rendering
+        - Gameplay
+        - Tools
+        - Docs
+        - Balance
+        - Performance
+        - Engine architecture
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should change?
+    validations:
+      required: true
+  - type: textarea
+    id: reason
+    attributes:
+      label: Why it matters
+      description: What problem does this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes or alternatives
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+Report security issues privately. Do not open public issues for vulnerabilities, token leaks, exploit chains, or destructive reproduction steps.
+
+## What To Report
+
+- Credential leaks or token exposure.
+- Remote code execution or command injection.
+- Unsafe file writes, path traversal, or archive extraction problems.
+- Network protocol issues that can crash, corrupt, or compromise a client or server.
+- Build or release pipeline weaknesses that could ship untrusted artifacts.
+
+## How To Report
+
+Use GitHub private vulnerability reporting when available for this repository. If it is not available, contact a ZSG Studios maintainer privately and include:
+
+- A concise summary.
+- Affected branch, build, or commit.
+- Reproduction steps.
+- Impact.
+- Suggested mitigation if known.
+
+We will confirm receipt, investigate, and coordinate disclosure or fixes before public details are posted.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+- 
+
+## Area
+
+- [ ] Client
+- [ ] Server
+- [ ] Basegame
+- [ ] Shared API
+- [ ] Tools
+- [ ] Build
+- [ ] Docs
+- [ ] Other
+
+## Validation
+
+- 
+
+## Rules Checklist
+
+- [ ] Change is scoped to one clear purpose.
+- [ ] Architecture boundaries are preserved.
+- [ ] No generated output, logs, secrets, or temporary files are included.
+- [ ] No copyrighted code or assets were copied from sources ZSG Studios cannot use.
+- [ ] Relevant issue or Discord report is linked when applicable.
+


### PR DESCRIPTION
## Summary
- Add contributor-facing project rules for issues, PRs, security reports, and conduct
- Add structured bug and feedback issue forms
- Add a PR checklist that matches Octaryn architecture boundaries and validation expectations

## Validation
- Parsed all issue template YAML files successfully
- Kept changes isolated to .github policy/template files

## Notes
- Existing branch rulesets remain unchanged